### PR TITLE
docs(brand): add the Blossom Star brand identity guide

### DIFF
--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,232 @@
+# Arkanis — Brand Identity (the _Blossom Star_)
+
+> The canonical reference for the Arkanis brand: the name, the mark, what they
+> mean, and how to apply them. Distilled from Delta's design notes so the
+> reasoning lives somewhere durable instead of in chat scrollback. The mark was
+> designed in `Logos/logo.afdesign` (Affinity Designer 2).
+
+A logo here is not decoration — it is the argument for who we are, made visually.
+The sections below capture _why_ each choice was made, because the why is what
+makes the identity hold up as the org grows beyond its first product.
+
+---
+
+## 1. The name — _Arkanis_
+
+- **Etymology:** _Magic → Arcane → Arkane → Arkanis._ The root is **magic** — not
+  Star Wars. (The "Arkanis sector" of that universe is a coincidence and a common
+  misread; correct it when you hear it.)
+- **It reads as a star.** Delta innately hears _Arkanis_ as a star — a
+  meaning the mark deliberately leans into rather than fights.
+- **Technology like magic.** The magic thread is a core brand feeling: what we
+  build should land as _technology that feels like magic_. We lean into
+  technology-as-magic, never literal wizardry — that keeps us clear of cliché.
+
+---
+
+## 2. The mark — _Blossom Star_
+
+An **eight-point neon burst** that reads at once as a **star** and a **flower
+blossom**, with a **clear-cut gem** at its centre. The point is the
+_intersection_: not a star _or_ a flower, but a star that is also a blossom.
+
+It unifies three ideas:
+
+| Element                  | Stands for                                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| **Star**                 | A shining example; a beacon for the community.                                                                          |
+| **Blossom**              | Organic, positive growth; communities that prosper around us.                                                           |
+| **Gem (clear-cut core)** | The **source**: where the vision and the colour originate, every value present at full strength; technology like magic. |
+
+**Design discipline.** The mark must stay simple and recognizable at small
+sizes — but _not simplistic_. Uniqueness, impact, and memorability outrank
+minimalism. We reject the generic vocabulary of tool logos (single letters,
+rockets, planets, gears, lightning bolts): they mean nothing.
+
+---
+
+## 3. What it means — the layers
+
+**A great mark carries many layers, not one.** The more values it encodes
+_without overloading the image_, the more facets people can find themselves in —
+and the more they can identify with us. Multi-layered is a requirement, not an
+indulgence: the mark has to represent everything we are, and ideally what we aim
+to become.
+
+| In the mark               | Reads as                                                                                         | Meaning                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| Eight petals              | A compass (cardinal + intermediate points)                                                       | A strong sense of **direction**.                                                        |
+| Clear-cut gem at the core | The most vibrant, most saturated point — the **source** the colour (and the values) radiate from | The **clear vision** itself: every value already present at the core, at full strength. |
+| Petals radiating outward  | Reaching every direction                                                                         | "We do it all — something for everyone."                                                |
+
+### The dual reading (the keystone)
+
+The **gem is Arkanis the corporation** — geometric, crystalline, engineering,
+the IRL company at the core. The **petals are Arkanis the community** — organic,
+blossoming, the growth that gathers around it. One mark holds both halves of the
+org at once, and that split _becomes a design language_ (see §7).
+
+Read it as **source and emanation**, not two halves side by side: everything is
+already present in the gem at full strength, and the petals are that core
+projecting itself outward — into the apps, the tools, the community, the future.
+A future, more literal artwork can show exactly this: the petals lit by the light
+shining _through_ the gem, its colours projected onto them.
+
+### The hidden star
+
+Look at the space _between_ the gem and the petals and a star appears in the
+negative space — a star inside the blossom. Three readings make it matter:
+
+- **It rewards a second look** — intentional negative space is a mark of serious
+  craft, and it makes this section's own claim literal: the more you look, the
+  more you find.
+- **It connects the halves** — the star sits between the gem (the company) and the
+  petals (the community), so what joins the two is itself a guiding star.
+- **It leaves room to shine** — a star held in open space is room kept open: for
+  us, for the community, for anyone who lets what Arkanis stands for inspire them.
+
+### Future expressions
+
+The identity is built to move. The intended evolution is an **animated mark**: a
+true 3D, crystalline gem at the centre whose facets shift colour as it turns
+(a custom shader — already a work-in-progress in Blender), with the petals
+unfolding from and around it. Through _source and emanation_, animation is the
+natural form — the core turning, throwing its colour outward, the petals catching
+the light it projects. A 3D gem may also reconcile the transparency the flat mark
+can't hold (see §5): facets that are at once cut, saturated, _and_ light-bearing.
+
+---
+
+## 4. Colour — the gradient is a feature
+
+The gradient is not styling; it lets the mark **say three things at the same
+time**:
+
+| Hue                      | Conveys                            |
+| ------------------------ | ---------------------------------- |
+| **Blue**                 | Trust, strength, reliability.      |
+| **Purple / violet**      | Creativity, imagination, wisdom.   |
+| **Red / pink (magenta)** | Excitement, playfulness, boldness. |
+
+The **gem at the centre defines _the_ colours.** It is not one coloured element
+among many — it is the **source**: where the vision is clearest and the colours
+are most vibrant and most saturated, because it is where everything originates.
+Every value we hold must be present _there_ first, at full strength, before it can
+radiate into anything we build. The mark then shows that radiation — colour born
+dense in the gem, blooming to white through the petals, cast outward to the bright
+tips: the core's light, thrown into the world.
+
+> **Why "brilliance" is exact:** in gemology, _brilliance_ is the measure of how
+> much light a cut stone returns. One of our core values is literally the property
+> the form is built to maximise — value and mark agree by construction, not
+> coincidence.
+
+**Working neon palette** (cyan → magenta on a **Delta Black** ground):
+
+| Role                    | Hex                                       |
+| ----------------------- | ----------------------------------------- |
+| Cyan (light endpoint)   | `#30F4EB` → `#38FFFF`                     |
+| Deep blue               | `#0015CA`                                 |
+| Violet                  | `#4300C0`                                 |
+| Magenta (warm endpoint) | `#FF39C8`                                 |
+| Ground                  | **Delta Black** `#0e0e0f`, or transparent |
+
+**Delta Black** (`#0e0e0f`) is the house neutral — a near-black that still reads
+as black, yet soft enough to sit easy on the eye instead of a harsh pure `#000`.
+Use it, or transparent, as the ground.
+
+> **Provenance / caveat:** the gradient endpoints above were sampled from the
+> glow gradients in `Icons/PatchWatch/glow_trim.svg` — treat them as the _working_
+> palette and confirm against `Logos/logo.afdesign` before publishing an official
+> token set. (`Delta Black` is a settled house value.)
+
+---
+
+## 5. Values
+
+**Who we are:** driven · innovative · perfectionist · revolutionary · passionate
+· creative · magnetic · transparent · honest · resilient · stable · inspiring
+· accessible · resourceful.
+
+**Who we are becoming** (the trajectory the brand should point at): reliable ·
+essential · universal.
+
+> _Transparency and honesty are held values, deliberately **not** depicted in the
+> current mark: a gem that is the clear, saturated **source** of the colour cannot
+> also be translucent — the two can't coexist in this iteration. The value stands;
+> the limitation is the medium. A future animated/3D gem may yet reconcile them
+> (see §3 — Future expressions)._
+
+---
+
+## 6. Positioning
+
+- **Star Citizen is the incubator, not the identity.** We focus on SC today, and
+  we genuinely enjoy it — but it is not our unique selling point, and the brand
+  must not be SC-centric or space-themed by default. The Overlay and the tools
+  around it generalize to many games and their communities. SC is where scope
+  _begins_, not where it ends.
+- **Two ledgers we build on.** At the **community** level we build relationships;
+  at the **company** level we establish trust, earn reputation, and form
+  partnerships — on the road to founding the company.
+- **The "odd one out" thesis.** Nearly every competing tool wears a hard,
+  angular, aggressive, space-themed mark. A flower deliberately contrasts ~90% of
+  that field. Done right — uniquely different without being upsetting or
+  distasteful — that contrast is the asset: the curiosity ("wait, what _is_
+  that?") becomes word-of-mouth, and nothing in marketing beats a genuine
+  recommendation from a trusted peer.
+- **Communicate, don't just reflect.** The mark should transmit our values,
+  ideally below conscious notice — not merely depict them.
+- **We include by making room, not by filling it.** To name who belongs is, by
+  the same gesture, to name who doesn't — so Arkanis grows by keeping the space
+  open rather than drawing lines around it. It is the hidden star made into a
+  principle (§3): open space is the invitation, and anyone who lets what we stand
+  for inspire them is already part of it.
+
+---
+
+## 7. Applying the brand — the design language
+
+The dual reading from §3 is the practical rule for any surface we make:
+
+- **Community-facing surfaces** lean into the **blossom**: organic, growing,
+  gradient-rich, warm, inviting.
+- **Engineering / corporate surfaces** lean into the **gem**: clear-cut,
+  geometric, precise, structured.
+- **Saturation encodes proximity to the core:** the deepest, purest neon belongs
+  to identity and hero moments (the gem); supporting surfaces lighten toward white
+  (the bloom). The mark tells us how to colour everything else.
+- **Surface aesthetic:** premium neon on dark — cyan → magenta on **Delta Black**
+  (`#0e0e0f`) or transparent.
+- **Legibility first:** keep the mark readable at small sizes; never simplify
+  away its identity to fit a favicon.
+
+Products inherit this language while carrying their own product icon (PatchWatch,
+for example, uses the "glow eye/lens," distinct from the corporate mark).
+
+---
+
+## 8. Asset index
+
+Each area self-documents with its own `README.md`; edit the `.afdesign` **source**
+and re-export via Affinity's Export Persona — never hand-edit the exports.
+
+- **The corporate mark — `Logos/`** (source: `Logos/logo.afdesign`)
+    - `Logos/color/` — the Blossom Star itself: `color_fill.*` (solid) and
+      `color_glow.*` (neon glow), as SVG / PNG / WebP at `@2x` and `@4x`.
+    - `Logos/name/horizontal/` and `Logos/name/vertical/` — mark + _Arkanis_
+      wordmark lockups, in **black** and **white** variants for light/dark grounds,
+      glow and flat.
+- **PatchWatch product icon — `Icons/PatchWatch/`** (source: `patchwatch.afdesign`)
+    - The "glow eye/lens": `glow.*` (primary), `glow_trim.*` (cropped),
+      `glow_bg.*` (on a plate), and `glow_dev.*` (dev-environment variant).
+    - This is a **product** icon, deliberately distinct from the corporate mark.
+- **Legacy — do not use.** `Icons/Regular`, `Icons/Small`, `Small_Inverted`,
+  `Small_Outlined`, and anything suffixed `_legacy` are the **old, AI-generated**
+  marks, kept only for history. The current identity is the Blossom Star in
+  `Logos/`.
+
+---
+
+_Distilled from the design notes of Delta (Merlin Brandes / FatalMerlin),
+2026-06-15. Brand inquiries: merlin@arkanis.cc._


### PR DESCRIPTION
Adds **`BRAND.md`** — the canonical Arkanis brand reference, distilled from Delta's design notes and greenlit by KronnY:

- The name (*Arkanis* — Magic → Arcane → Arkane → Arkanis) and the **Blossom Star** mark: a star *and* a flower blossom at once, a clear-cut gem at the core, and a hidden star in the negative space.
- The symbolic layers, the gem-as-source / "defines the colours" reading, and the dual reading (gem = the company, petals = the community).
- Colour — the neon palette + **Delta Black** (`#0e0e0f`).
- Values; positioning (the "odd one out" thesis; *"we include by making room, not by filling it"*); and the blossom/gem **design language**.
- An asset index pointing at the current Blossom Star (`Logos/`) and the PatchWatch eye (`Icons/PatchWatch/`), with the legacy marks flagged off-limits.

Baseline for the brand going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)